### PR TITLE
Project 3 - Supplementary page table, frame

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,11 @@
         "*.inc": "c",
         "process.h": "c",
         "*.tcc": "c",
-        "fstream": "c"
+        "fstream": "c",
+        "filesys.h": "c",
+        "cstdlib": "c"
+    },
+    "editor.tokenColorCustomizations": {
+        "comments": "#ffffff"
     }
 }

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -121,7 +121,6 @@ struct thread
 	struct semaphore free_sema;
 
 	/* -- Project 3 --*/
-	struct supplemental_page_table spt;
 
 	int stdin_count;
 	int stdout_count;

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -122,8 +122,8 @@ struct thread
 
 	/* -- Project 3 --*/
 
-	int stdin_count;
-	int stdout_count;
+	uintptr_t rsp;
+	void *stack_bottom;
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -2,6 +2,7 @@
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
+#include "lib/kernel/hash.h"
 
 enum vm_type {
 	/* page not initialized */
@@ -63,6 +64,10 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
+
+	/* -- Project 3 -- */
+	bool accessed;
+	bool dirty;
 };
 
 /* The function table for page operations.

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -66,10 +66,17 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
+};
 
-	/* -- Project 3 -- */
-	bool accessed;
-	bool dirty;
+/* -- Project3 -- */
+struct aux_struct {
+	struct file *vmfile;
+	off_t ofs;
+	uint32_t read_bytes;
+	uint32_t zero_bytes;
+	bool is_loaded;
+	bool writable;
+	uint8_t upage;
 };
 
 /* The function table for page operations.

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -48,6 +48,8 @@ struct page {
 
 	/* Your implementation */
 	struct hash_elem hash_elem;
+	bool writable;
+	void *aux;
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
 	union {
@@ -90,7 +92,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
-	struct hash spt_hash_table;
+	struct hash *spt_hash_table;
 };
 
 #include "threads/thread.h"

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -132,13 +132,13 @@ void syscall_handler(struct intr_frame *f UNUSED)
 void check_address(void *addr)
 {
     struct thread *curr = thread_current();
-    // user virtual address 인지 ; 커널 VM이 아닌지
-    // 주소가 NULL 은 아닌지
-    // 유저 주소 영역내를 가르키지만 아직 할당되지 않았는지 (pml4_get_page)
-    if (!is_user_vaddr(addr) || addr == NULL || pml4_get_page(curr->pml4, addr) == NULL)
-    {
+    #ifdef VM
+    if (addr == NULL || is_kernel_vaddr(addr) || spt_find_page(&curr->spt, addr) == NULL)
         exit(-1);
-    }
+    #else
+    if (addr == NULL || is_kernel_vaddr(addr) || pml4_get_page(curr->pml4, addr) == NULL)
+        exit(-1);
+    #endif
 }
 
 void halt(void)

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -49,4 +49,10 @@ anon_swap_out (struct page *page) {
 static void
 anon_destroy (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+	if(page->frame) {
+		palloc_free_page(page->frame->kva);
+		free(page->frame);
+	}
+	pml4_clear_page(thread_current()->pml4, page->va);
+	free(page);
 }

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -65,4 +65,10 @@ uninit_destroy (struct page *page) {
 	struct uninit_page *uninit UNUSED = &page->uninit;
 	/* TODO: Fill this function.
 	 * TODO: If you don't have anything to do, just return. */
+	if(page->frame) {
+		palloc_free_page(page->frame->kva);
+		free(page->frame);
+	}
+	pml4_clear_page(thread_current()->pml4, page->va);
+	free(page);
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -83,7 +83,7 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 }
 /* 해시 요소들 비교 */
 bool
-page_compare (const struct hash_elem *a, const struct hash_elem *b, void *aux UNUSED)
+hash_less (const struct hash_elem *a, const struct hash_elem *b, void *aux UNUSED)
 {
 	const struct page *a_p = hash_entry(a, struct page, hash_elem);
 	const struct page *b_p = hash_entry(b, struct page, hash_elem);
@@ -208,7 +208,7 @@ void
 supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
 	struct hash *hash_table = (struct hash*)malloc(sizeof(struct hash));
 	spt->spt_hash_table = *hash_table;
-	hash_init(&spt->spt_hash_table, hash_func, page_compare, NULL);
+	hash_init(&spt->spt_hash_table, hash_func, hash_less, NULL);
 }
 
 /* Copy supplemental page table from src to dst */


### PR DESCRIPTION
# Memory Management

## Implement Supplemental Page Table

```c
/* Initialize new supplemental page table */
void
supplemental_page_table_init (struct supplemental_page_table *spt UNUSED)
{
	hash_init(&spt->spt_hash_table, hash_func, hash_less, NULL);
}
```

> 보조 테이블 초기화, process.c 의 `initd()`  함수로 새로운 프로세스가 시작하거나 process.c의 `__do_fork()`로 자식 프로세스가 생성될 때 호출된다.

```c
/* Find VA from spt and return page. On error, return NULL. */
struct page *
spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED)
{
	/* TODO: Fill this function. */
	struct page page;
	page.va = pg_round_down(va);
	struct hash_elem *e = hash_find (&spt->spt_hash_table, &(page.hash_elem));
	
	return e ? hash_entry(e, struct page, hash_elem) : NULL;
}
```
> 인자로 넘겨진 spt 에서부터 가상주소(va) 와 대응되는 페이지 구조체를 찾아서 반환한다. 실패했을경우 NULL 반환.

```c
/* Insert PAGE into spt with validation. */
bool
spt_insert_page (struct supplemental_page_table *spt UNUSED, struct page *page UNUSED)
{
	/* TODO: Fill this function. */
	int success = false;
	if(hash_insert(&(spt->spt_hash_table), &(page->hash_elem)) == NULL) {
		success = true;
	}
	return success;
}
```
> 인자로 주어진 spt에 페이지 구조체 삽입. spt에 가상 주소가 존재하는지 확인해야한다.


## Frame Management

```c
/* The representation of "frame" */
struct frame {
  void *kva;
  struct page *page;
};
```

```c
/* palloc() and get frame. If there is no available page, evict the page
* and return it. This always return valid address. That is, if the user pool
* memory is full, this function evicts the frame to get the available memory
* space.*/
static struct frame *
vm_get_frame (void)
{
	/* TODO: Fill this function. */
	struct frame *frame = (struct frame*)malloc(sizeof(struct frame));
	frame->kva = palloc_get_page(PAL_USER);
	frame->page = NULL;
  
	if (frame->kva == NULL) {
		// PANIC("todo");
		frame = NULL;
	}
  
	ASSERT (frame != NULL);
	ASSERT (frame->page == NULL);
	return frame;
}
```
> `palloc_get_page()` 호출함으로써 메모리 풀에서 새로운 물리 메모리 페이지를 가져온다.
> **유저 메모리 풀에서 페이지를 성공적으로 가져오면**, 프레임을 할당하고 프레임 구조체의 멤버를 초기화한 후 해당 프레임 반환.

```c
/* Claim the PAGE and set up the mmu. */
static bool
vm_do_claim_page (struct page *page)
{
	struct frame *frame = vm_get_frame ();
	/* Set links */
	if(frame == NULL) {
		frame = vm_evict_frame();
	}
	/* 링크 */
	frame->page = page;
	page->frame = frame;
	/* TODO: Insert page table entry to map page's VA to frame's PA. */
	pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable);
	
	return swap_in (page, frame->kva);
}
```
> 인자로 주어진 page에 물리 메모리 frame 할당
> `vm_get_frame()` 함수를 호출함으로써 프레임 하나를 얻어서
> MMU 세팅 ( 가상 주소와 물리 주소를 매핑한 정보를 페이지 테이블에 추가해야 한다)
> 성공시 true, 실패시 false

```c
/* Claim the page that allocate on VA. */
bool
vm_claim_page (void *va UNUSED)
{
	/* TODO: Fill this function */
	struct page *page = spt_find_page (&thread_current ()->spt, va);
	if (!page)
		return false;
	return vm_do_claim_page (page);
}
```
> 인자로 주어진 va에 페이지를 할당하고 해당 페이지에 프레임을 할당
> 한 페이지를 얻어서 해당 페이지를 인자로 갖는 `vm_do_claim_page()` 호출

---

# Anonymous Page

## Page Initialization with Lazy Loading

>지연 로딩은 필요 시점까지 메모리의 로딩을 지연시키는 방법입니다. ==페이지가 할당되었다는 것은 대응되는 페이지 구조체는 있지만 연결된 물리 메모리 프레임은 아직 없고 페이지에 대한 실제 콘텐츠들이 아직 로드되지 않았다는 것을 의미합니다. 콘텐츠는 페이지 폴트로 인해 실제로 콘텐츠가 필요하다는 시그널을 받을 때 로드됩니다.==

`초기화 👉 페이지 폴트 👉 지연 로딩 👉 스왑 인 👉 스왑 아웃 👉 . . . 👉 삭제` 
`vm_alloc_page_with_initializer() 👉 uninit_initialize() 👉 (anon, file_backed)`

## Lazy Loading for Executable

![IMG_37E407579D8B-1](https://github.com/whwogur/PintOS_Project3/assets/111280407/af45a2a0-b45e-40fc-818e-127015f17efc)


```c
/* Create the pending page object with initializer. If you want to create a
* page, do not create it directly and make it through this function or
* `vm_alloc_page`. */
bool
vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable, vm_initializer *init, void *aux)
{
	ASSERT (VM_TYPE(type) != VM_UNINIT)
	bool success = false;
	struct supplemental_page_table *spt = &thread_current()->spt;
	/* Check wheter the upage is already occupied or not. */
	if (spt_find_page (spt, upage) == NULL) {
	/* TODO: Create the page, fetch the initialier according to the VM type,
	* TODO: and then create "uninit" page struct by calling uninit_new. You
	* TODO: should modify the field after calling the uninit_new. */
		struct page *p = (struct page *)malloc(sizeof(struct page));
		switch(VM_TYPE(type)) {
			case VM_ANON:
				uninit_new(p, pg_round_down(upage), init, type, aux, anon_initializer);
				break;
			case VM_FILE:
				uninit_new(p, pg_round_down(upage), init, type, aux, file_backed_initializer);
				break;
	}
	p->writable = writable;
	/* TODO: Insert the page into the spt. */
	success = spt_insert_page(spt, p);
	return success;
}
err:
	return success;
}
```

>uninit type 페이지 생성.
>uninit 페이지의 swap in 핸들러는 자동적으로 페이지 타입에 맞게 페이지 초기화하고 주어진 aux를 인자로 삼는 init 함수 호출(?)
>uninit 페이지 생성되면 프로세스의 spt에 페이지 삽입해야한다. (VM_TYPE) 매크로 사용


---

```c
/* Initalize the page on first fault */
static bool
uninit_initialize (struct page *page, void *kva)
{
	struct uninit_page *uninit = &page->uninit;
	/* Fetch first, page_initialize may overwrite the values */
	vm_initializer *init = uninit->init;
	void *aux = uninit->aux;
	/* TODO: You may need to fix this function. */
	return uninit->page_initializer (page, uninit->type, kva) && (init ? init (page, aux) : true);
}
```

>이미 짜여져있는 함수,
>처음으로 폴트가 발생한 페이지를 초기화한다.
>uninit 페이지의 멤버변수인 vm_initializer, aux를 가져온 후 알맞은 page_initializer 호출

---

```c
/* Initialize the data for anonymous pages */
void
vm_anon_init (void)
{
	/* TODO: Set up the swap_disk. */
	swap_disk = NULL;
}
```

> anon 페이지 서브시스템(?) 초기화

---

```c
/* Initialize the file mapping */
bool
anon_initializer (struct page *page, enum vm_type type, void *kva)
{
	/* Set up the handler */
	page->operations = &anon_ops;
	struct anon_page *anon_page = &page->anon;
}
```

>page->operation에 있는 anon 페이지 핸들러 설정
>anon 페이지 초기화하는데 사용

---

```c
static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t read_bytes, uint32_t zero_bytes, bool writable)
{
	ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
	ASSERT(pg_ofs(upage) == 0);
	ASSERT(ofs % PGSIZE == 0);
	while (read_bytes > 0 || zero_bytes > 0) {
		/* Do calculate how to fill this page.
		* We will read PAGE_READ_BYTES bytes from FILE
		* and zero the final PAGE_ZERO_BYTES bytes. */
		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
		size_t page_zero_bytes = PGSIZE - page_read_bytes;
		/* TODO: Set up aux to pass information to the lazy_load_segment. */
		struct aux_struct *tmp_aux = (struct aux_struct *)malloc(sizeof(struct aux_struct));
		tmp_aux->vmfile = file;
		tmp_aux->ofs = ofs;
		tmp_aux->read_bytes = page_read_bytes;
		tmp_aux->zero_bytes = page_zero_bytes;
		tmp_aux->writable = writable;
		tmp_aux->upage = upage;
		void *aux = tmp_aux;
		if(!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, aux))
			return false;
		/* Advance. */
		read_bytes -= page_read_bytes;
		zero_bytes -= page_zero_bytes;
		upage += PGSIZE;
		ofs += page_read_bytes;
	}
	return true;
}
```
>루프 돌 때 마다 페이지 대기중인 페이지 오브젝트 생성-> 페이지 폴트 발생 시 세그먼트가 파일에서 로드된다.
>`vm_alloc_page_with_initializer()`에 제공할 aux 인자의 값들 설정해야함 -> 구조체 생성

---

```c
static bool
lazy_load_segment(struct page *page, struct aux_struct *aux)
{
	/* TODO: Load the segment from the file */
	/* TODO: This called when the first page fault occurs on address VA. */
	/* TODO: VA is available when calling this function. */
	/* ---- Project 3 ---- */
	if(file_read_at(aux->vmfile, page->frame->kva, aux->read_bytes, aux->ofs)
			!= (int)aux->read_bytes) {
			
			palloc_free_page(page->frame->kva);
			free(aux);
			return false;
	}
	memset(page->frame->kva + aux->read_bytes, 0, aux->zero_bytes);
	free(aux);
	
	return true;
}
```
>실행 가능한 파일의 페이지들을 초기화하는 함수, page fault가 발생할때 호출된다.
>인자로 받는 aux는 load_segment에서 설정해주는 정보
>이 함수로 세그먼트를 읽을 파일을 찾고 최종적으로 세그먼트를 메모리에서 읽어야한다.

---

```c
/* Create a PAGE of stack at the USER_STACK. Return true on success. */
static bool
setup_stack(struct intr_frame *if_)
{
	bool success = false;
	void *stack_bottom = (void *)(((uint8_t *)USER_STACK) - PGSIZE);
	/* TODO: Map the stack on stack_bottom and claim the page immediately.
	* TODO: If success, set the rsp accordingly.
	* TODO: You should mark the page is stack. */
	/* TODO: Your code goes here */
	if(vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_0, stack_bottom, true, NULL, NULL)) {
		success = vm_claim_page(stack_bottom);
		if_->rsp = USER_STACK;
		thread_current()->stack_bottom = stack_bottom;
	}
	
	return success;
}
```

>첫 스택 페이지는 Lazy load 될 필요가 없다
>페이지 폴트가 발생하는걸 기다릴 필요 없이 스택 페이지를 load time때 커맨드 라인 인자들과 함께 할당 & 초기화
>VM_MARKER_0 사용

---

> `spt_find_page()` 를 통해 페이지 폴트를 일으킨 주소에 대해 페이징 해결
