### PR TITLE
feat: mmap and munmap 13 / 141

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -121,9 +121,8 @@ struct thread
 	struct semaphore free_sema;
 
 	/* -- Project 3 --*/
-
-	uintptr_t rsp;
 	void *stack_bottom;
+	struct bitmap *disk_table;
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -1,10 +1,15 @@
 #ifndef VM_ANON_H
 #define VM_ANON_H
 #include "vm/vm.h"
+
+#include <bitmap.h>
+
 struct page;
 enum vm_type;
 
 struct anon_page {
+    /* -- Project 3 -- */
+    size_t swap_slot;
 };
 
 void vm_anon_init (void);

--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -7,6 +7,11 @@ struct page;
 enum vm_type;
 
 struct file_page {
+	uint32_t read_byte;
+	uint32_t zero_byte;
+	enum vm_type type;
+	struct file *file;
+	off_t offset;
 };
 
 void vm_file_init (void);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -99,7 +99,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
-	struct hash *spt_hash_table;
+	struct hash spt_hash_table;
 };
 
 #include "threads/thread.h"

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -21,7 +21,11 @@ static const struct page_operations anon_ops = {
 void
 vm_anon_init (void) {
 	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
+	/* -- Project 3 -- */
+	swap_disk = disk_get(1, 1);
+	// disk sector 크기 = 512bytes
+	// page 크기 = 4KB = 512 * 8 bytes = disk sector * 8
+	thread_current()->disk_table = bitmap_create(disk_size(swap_disk) / 8);
 }
 
 /* Initialize the file mapping */
@@ -37,12 +41,38 @@ anon_initializer (struct page *page, enum vm_type type, void *kva) {
 static bool
 anon_swap_in (struct page *page, void *kva) {
 	struct anon_page *anon_page = &page->anon;
+	/* -- Project 3 -- */
+	struct disk *disk = thread_current()->disk_table;
+	size_t sector_slot = page->anon.swap_slot;
+	disk_read(disk, sector_slot, kva);
+	bitmap_set(disk, sector_slot, false);
+
+	return true;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
 static bool
 anon_swap_out (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+	/* -- Project 3 -- */
+	/* 테이블 순회해서 swap_slot이 1이 아닌것을 찾음 */
+	struct disk *disk = thread_current()->disk_table;
+
+	size_t empty_slot = bitmap_scan(disk, 0, 1, false);
+
+	if(empty_slot == BITMAP_ERROR) {
+		PANIC("empty_slot, BITMAP_ERROR");
+	}
+	page->anon.swap_slot = empty_slot;
+	disk_write(disk, empty_slot, page->frame->kva);
+	bitmap_set(disk, empty_slot, true);
+	
+	if(page->frame) {
+		palloc_free_page(page->frame->kva);
+	}
+	pml4_clear_page(thread_current()->pml4, page->va);
+	
+	return true;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */

--- a/vm/file.c
+++ b/vm/file.c
@@ -1,6 +1,9 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
 #include "vm/vm.h"
+#include "threads/vaddr.h"
+#include "threads/mmu.h"
+#include "include/threads/malloc.h"
 
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
@@ -26,6 +29,37 @@ file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 	page->operations = &file_ops;
 
 	struct file_page *file_page = &page->file;
+
+	/* -- Project 3 -- */
+	struct aux_struct *dummy = (struct aux_struct *)page->uninit.aux;
+
+	file_page->file = dummy->vmfile;
+	file_page->offset = dummy->ofs;
+	file_page->read_byte = dummy->read_bytes;
+	file_page->zero_byte = dummy->zero_bytes;
+	file_page->type = type;
+
+	if(file_read_at(dummy->vmfile, kva, dummy->read_bytes, dummy->ofs)
+												!= dummy->read_bytes) {
+		return false;
+	}
+	return true;
+}
+
+static bool
+lazy_load_file(struct page *page, struct aux_struct *aux)
+{
+	/* -- Project 3 -- */
+	if(file_read_at(page->file.file, page->frame->kva, page->file.read_byte,
+					page->file.offset) != (int32_t) page->file.read_byte) {
+		palloc_free_page(page->frame->kva);
+		free(aux);
+		return false;
+	}
+	memset(page->frame->kva + page->file.read_byte, 0, page->file.zero_byte);
+	free(aux);
+
+	return true;
 }
 
 /* Swap in the page by read contents from the file. */
@@ -44,15 +78,72 @@ file_backed_swap_out (struct page *page) {
 static void
 file_backed_destroy (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
+
+	if (page->frame) {
+		palloc_free_page(page->frame->kva);
+		free(page->frame);
+	}
+	pml4_clear_page(thread_current()->pml4, page->va);
+	free(page);
 }
 
-/* Do the mmap */
+/* 
+ * offset 바이트에서 시작해 addr에 있는 프로세스의 가상 주소 공간에 fd로 열린 파일의 length 바이트 매핑
+ * 전체 파일은 addr에서 시작하는 연속적인 가상 페이지에 매핑
+ * 파일 길이가 PGSIZE의 배수가 아니면 매핑된 최종 페이지의 일부 바이트가 파일 끝을 넘어 삐져나옴
+ * 페이지에 오류가 발생하면 이 바이트를 0으로 설정하고 페이지를 디스크에 다시 쓸 때 버림
+ * 성공하면 이 함수는 파일이 매핑된 가상 주소를 반환한다
+ * 
+ * Linux에서는 addr이 NULL이면 커널은 매핑을 생성한 적절한 주소를 찾는다
+ * 그래서 addr이 0이면 일부 Pintos 코드는 가상 페이지 0이 매핑되지 않았다고 가정, 실패함
+ * length가 0일때도 mmap 실패해야 함.
+ */
 void *
 do_mmap (void *addr, size_t length, int writable,
 		struct file *file, off_t offset) {
+	
+	off_t read_size = file_length(file);
+
+	void *va = addr;
+
+	while(0 < read_size) {
+		struct aux_struct *temp_aux = (struct aux_struct *)malloc(sizeof(struct aux_struct));
+
+		uint32_t read_bytes = read_size > PGSIZE ? PGSIZE : read_size;
+
+		temp_aux->vmfile = file;
+		temp_aux->ofs = offset;
+		temp_aux->read_bytes = read_bytes;
+		temp_aux->zero_bytes = PGSIZE - read_bytes;
+		temp_aux->writable = writable;
+		temp_aux->upage = va;
+
+		if(!vm_alloc_page_with_initializer(VM_FILE, va, writable, lazy_load_file, temp_aux))
+			return NULL;
+		read_size -= read_bytes;
+		va += PGSIZE;
+		offset += read_bytes;
+	}
+	return addr;
 }
 
 /* Do the munmap */
 void
 do_munmap (void *addr) {
+	
+	struct page *page = spt_find_page(&thread_current()->spt, pg_round_down(addr));
+
+	struct file *file = page->file.file;
+	off_t read_size = file_length(file);
+
+	while(page = spt_find_page(&thread_current()->spt, addr)) {
+		if(page->file.file != file)
+			return;
+		
+		if(pml4_is_dirty(thread_current()->pml4, addr)) {
+			pml4_set_dirty(thread_current()->pml4, addr, false);
+			file_write_at(page->file.file, addr, page->file.read_byte, page->file.offset);
+		}
+		addr += PGSIZE;
+	}
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -172,6 +172,8 @@ vm_get_frame (void) {
 /* Growing the stack. */
 static void
 vm_stack_growth (void *addr UNUSED) {
+	/* -- Project 3 -- */
+	vm_alloc_page(VM_ANON | VM_MARKER_0, addr, true);
 }
 
 /* Handle the fault on write_protected page */
@@ -274,6 +276,7 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 		struct supplemental_page_table *src UNUSED)
 {
 	hash_apply(&src->spt_hash_table, copy_page);
+	return true;
 }
 void
 kill_page(struct hash_elem *e, void *aux)


### PR DESCRIPTION
```c
struct file_page
{
	uint32_t read_byte;
	uint32_t zero_byte;
	enum vm_type type;
	struct file *file;
	off_t offset;
};
```

---

```c
/* -- Project 3 -- */
void*
mmap(void *addr, size_t length, int writable, int fd, off_t offset)
{
	if ((signed)length <= 0 || length < offset)
		return NULL;
	if(!addr || fd < 2 || is_kernel_vaddr(addr) || pg_ofs(addr))
		return NULL;
	struct file* file = file_reopen(thread_current()->fd_table[fd]);
	return do_mmap(addr, length, writable, file, offset);
}
```
```c
/* Opens and returns a new file for the same inode as FILE.
* Returns a null pointer if unsuccessful. */
struct file *
file_reopen (struct file *file)
{
	return file_open (inode_reopen (file->inode));
}
```

>> Maps length bytes the file open as fd starting from offset byte into the process's virtual address space at addr. The entire file is mapped into consecutive virtual pages starting at addr. 
> 
>If the length of the file is not a multiple of PGSIZE, then some bytes in the final mapped page "stick out" beyond the end of the file. Set these bytes to zero when the page is faulted in, and discard them when the page is written back to disk. If successful, this function returns the virtual address where the file is mapped. On failure, it must return NULL which is not a valid address to map a file.

>A call to `mmap()` may fail if 
>- the file opened as fd ==has a length of 0 bytes==. 
>- It must fail if ==addr is not page-aligned ==
>- ==or if the range of pages mapped overlaps any existing set of mapped pages, including the stack or pages mapped at executable load time==.

```c
/* Offset 바이트에서 시작해 addr에 있는 프로세스의 가상 주소 공간에 fd로 열린 파일의
 * length 바이트 매핑.
 * 파일 길이가 PGSIZE의 배수가 아니면 매핑된 최종 페이지의 일부 바이트가 삐져나옴
 * 페이지에 오류가 발생하면 바이트 0으로 설정하고 페이지를 디스크에 다시 쓸 때 버림
 */
void *
do_mmap (void *addr, size_t length, int writable,
			struct file *file, off_t offset)
{
	off_t read_size = file_length(file);
	void *va = addr; 
	while(0 < read_size) {
		struct aux_struct *temp_aux = (struct aux_struct *)malloc(sizeof(struct aux_struct));
		uint32_t read_bytes = read_size > PGSIZE ? PGSIZE : read_size;
		temp_aux->vmfile = file;
		temp_aux->ofs = offset;
		temp_aux->read_bytes = read_bytes;
		temp_aux->zero_bytes = PGSIZE - read_bytes;
		temp_aux->writable = writable;
		temp_aux->upage = va;
		if(!vm_alloc_page_with_initializer(VM_FILE, va, writable,
												 lazy_load_file, temp_aux))
			return NULL;
		read_size -= read_bytes;
		va += PGSIZE;
		offset += read_bytes;
	}
	return addr; // load_segment()와 달리 유저 페이지의 첫 주소 리턴
}
```

>Memory-mapped pages should be also allocated in a lazy manner just like anonymous pages. You can use `vm_alloc_page_with_initializer()` or `vm_alloc_page()` to make a page object.

---
#munmap
```c
void*
munmap(void *addr)
{
	if(is_kernel_vaddr(addr))
		return NULL;
	do_munmap(addr);
}
```

>매핑을 해제하려는 페이지는 `mmap()`으로 할당된 가상 페이지여야 하며, 이 페이지는 `mmap()`으로 할당 할 당시의 유저 프로세스와 동일한 프로세스여야한다.

```c
void
do_munmap (void *addr)
{
	struct page *page = spt_find_page(&thread_current()->spt,
														pg_round_down(addr));
	struct file *file = page->file.file;
	off_t read_size = file_length(file);
	while(page = spt_find_page(&thread_current()->spt, addr)) {
		if(page->file.file != file)
			return;
		if(pml4_is_dirty(thread_current()->pml4, addr)) {
			pml4_set_dirty(thread_current()->pml4, addr, false);
			file_write_at(page->file.file, addr, page->file.read_byte, 
														page->file.offset);
		}
		addr += PGSIZE;
	}
}
```

>종료를 통하거나 다른 방법을 통해 프로세스가 exit되면 모든 매핑이 암시적으로 매핑 해제됩니다. 암시적이든 명시적이든 매핑이 매핑 해제되면 프로세스에서 쓴 모든 페이지는 파일에 다시 기록되며 기록되지 않은 페이지는 기록되지 않아야 합니다. 그런 다음 해당 페이지는 프로세스의 가상 페이지 목록에서 제거됩니다

>파일을 닫거나 제거해도 해당 매핑이 매핑 해제되지 않습니다. 생성된 매핑은 Unix 규칙에 따라 munmap이 호출되거나 프로세스가 종료될 때까지 유효합니다. 자세한 내용은  [Removing an Open File](https://casys-kaist.github.io/pintos-kaist/project2/FAQ.html)를 참조하세요. 각 매핑에 대해 파일에 대한 개별적이고 독립적인 참조를 얻으려면 file_reopen 함수를 사용해야 합니다.

>If two or more processes map the same file, there is no requirement that they see consistent data. Unix handles this by making the two mappings share the same physical page, and the `mmap` system call also has an argument allowing the client to specify whether the page is shared or private (i.e. copy-on-write).

```c
bool
file_backed_initializer (struct page *page, enum vm_type type, void *kva)
{
	/* Set up the handler */
	page->operations = &file_ops;
	struct file_page *file_page = &page->file;

	/* -- Project 3 -- */
	struct aux_struct *dummy = (struct aux_struct *)page->uninit.aux;
	file_page->file = dummy->vmfile;
	file_page->offset = dummy->ofs;
	file_page->read_byte = dummy->read_bytes;
	file_page->zero_byte = dummy->zero_bytes;
	file_page->type = type;
	if(file_read_at(dummy->vmfile, kva, dummy->read_bytes, dummy->ofs)
													!= dummy->read_bytes) {
		return false;
	}
	return true;
}
```

```c
/* Destory the file backed page. PAGE will be freed by the caller. */
static void
file_backed_destroy (struct page *page)
{
	struct file_page *file_page UNUSED = &page->file;
	if (page->frame) {
		palloc_free_page(page->frame->kva);
		free(page->frame);
	}
	pml4_clear_page(thread_current()->pml4, page->va);
	free(page);
}
```
>관련 파일을 닫아 파일 지원 페이지를 파괴합니다. 내용이 dirty인 경우 변경 사항을 파일에 다시 기록해야 합니다. 이 함수에서 페이지 구조를 `free`할 필요는 없습니다. `file_backed_destroy`의 호출자는 이를 처리해야 합니다.
---
# 흐름
#흐름, #syscall

```
맨 처음 파일을 가상 페이지에 할당할 때
```

>--------------- Pintos 부팅 -------------------
>-> **init.c** 실행
  -> ... ->**run_actions()**
  -> **run_task()**
  -> **process_create_initd()**
  -> **initd()** -> **spt_init()**으로 spt 테이블 초기화되고
  -> **process_exec()**
  -> **load()**: 입력으로 넣어준 file_name에 해당하는 실행 파일을 현재 스레드에 load
  -> **load_segment()**: container 구조체 생성해 해당 구조체에 파일 메타데이터(파일 구조체, page_read_byte, offset)를 저장한 뒤 **vm_alloc_page_with_initializer()**를 호출
  ->vm_alloc_page_with_initializer(): 해당 파일 형태(uninit/anonymous/file-backed)에 맞게 초기화해준다.

```
프로세스가 페이지만 할당되어 있는 가상 주소에 접근한 상황 발생
```

>**exception_init()**: exception 발생: handler가 작동한다.
->**page_fault()**: 해당 페이지에 정보가 있다고 해서 가봤더니 정보가 없다. 그러면 page fault가 발동한다.
->**vm_try_handle_fault()**: 먼저 유저 스택 포인터를 가지고 온다.
-> **vm_claim_page()**: 그 다음, 해당 인자로 받은 가상 주소에 해당하는 페이지를 spt 테이블로부터 들고온다.
->**vm_do_claim_page()**
-> **vm_get_frame():** 물리 프레임을 할당받아 온다.
-> **install_page()**: 위에서 받아온 물리 프레임과 가상 페이지를 연결한다.